### PR TITLE
Add exclude for vendor

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: An awesome docs project
 permalink: pretty
 search_enabled: true
 color_scheme: dark
+exclude: [vendor]
 
 remote_theme: pmarsceill/just-the-docs
 plugins:

--- a/script/testlinks
+++ b/script/testlinks
@@ -1,2 +1,2 @@
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html
+bundle exec htmlproofer ./_site --external_only


### PR DESCRIPTION
Travis bundles all gems in the vendor directory on its build servers, which Jekyll will mistakenly read and explode on. To avoid this, exclude vendor in your _config.yml: